### PR TITLE
#7 sign 디자인 구현

### DIFF
--- a/web/src/components/sign/sign-ui.tsx
+++ b/web/src/components/sign/sign-ui.tsx
@@ -1,0 +1,26 @@
+import { Dot } from '@/components/ui/dot';
+
+export default function SignUi() {
+  return (
+    <>
+      <div className="absolute right-0 top-0 pr-3 pt-3 text-white">
+        <Dot />
+      </div>
+      <div className="relative z-30 flex flex-col justify-center pl-4 md:pl-24 md:pr-12 xl:pr-12">
+        <h3 className="text-4xl font-extrabold leading-tight text-white">
+          MyNote <br />
+          Schedule &amp;
+          <br />
+          Issue Management
+        </h3>
+        <p className="hidden pt-3 text-xl leading-normal text-white sm:block xl:w-10/12">
+          MyNote는 개인이 혼자 컨트롤하기 어려웠던 스케쥴 관리와 개인 프로젝트
+          일정 관리를 해결하는데 도움을 주는 애플리케이션입니다.
+        </p>
+      </div>
+      <div className="absolute bottom-0 left-0 z-20 pb-3 pl-3 text-white">
+        <Dot />
+      </div>
+    </>
+  );
+}

--- a/web/src/components/sign/signin-form.tsx
+++ b/web/src/components/sign/signin-form.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { signinSchema } from '@/lib/schemas/signin.schema';
+
+export default function SigninForm() {
+  const form = useForm<z.infer<typeof signinSchema>>({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    resolver: zodResolver(signinSchema),
+  });
+
+  const submitHandler = async (values: z.infer<typeof signinSchema>) => {
+    console.log(values);
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center p-8 lg:w-1/2">
+      <h1 className="mb-6 text-3xl font-bold">MyNote</h1>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(submitHandler)}
+          className="flex w-full flex-col gap-4 sm:w-[60%]"
+        >
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">Email</FormLabel>
+                <FormControl>
+                  <Input type="text" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">Password</FormLabel>
+                <FormControl>
+                  <Input type="text" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="mt-4 flex w-full items-center justify-between">
+            <Link to="/sign?type=up">
+              아직 회원이 아니신가요?
+              <br />
+              <span className="font-semibold text-indigo-400">회원가입</span>
+              으로 이동하기
+            </Link>
+            <Button variant="outline" className="bg-indigo-400 text-white">
+              로그인
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/web/src/components/sign/signup-form.tsx
+++ b/web/src/components/sign/signup-form.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { signupSchema } from '@/lib/schemas/signup.schema';
+import { FileUpload } from '@/components/ui/file-upload';
+
+export default function SignupForm() {
+  const form = useForm<z.infer<typeof signupSchema>>({
+    defaultValues: {
+      nickname: '',
+      email: '',
+      password: '',
+      profileImage: '',
+    },
+    resolver: zodResolver(signupSchema),
+  });
+
+  const submitHandler = async (values: z.infer<typeof signupSchema>) => {
+    try {
+      console.log(values);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center p-8 lg:w-1/2">
+      <h1 className="mb-6 text-3xl font-bold">ChatLink</h1>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(submitHandler)}
+          className="flex w-full flex-col gap-4 sm:w-[60%]"
+        >
+          <FormField
+            control={form.control}
+            name="nickname"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">Nickname</FormLabel>
+                <FormControl>
+                  <Input type="text" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">Email</FormLabel>
+                <FormControl>
+                  <Input type="text" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">Password</FormLabel>
+                <FormControl>
+                  <Input type="text" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="profileImage"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-lg font-bold">
+                  ProfileImage
+                </FormLabel>
+                <FormControl>
+                  <FileUpload field={field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <div className="mt-4 flex w-full items-center justify-between">
+            <Link to="/sign?type=in">
+              이미 회원이신가요?
+              <br />
+              <span className="font-semibold text-indigo-400">로그인</span>
+              으로 이동하기
+            </Link>
+            <Button variant="outline" className="bg-indigo-400 text-white">
+              회원가입
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/web/src/components/ui/file-upload.tsx
+++ b/web/src/components/ui/file-upload.tsx
@@ -1,0 +1,78 @@
+import { checkImage, readAsBase64 } from '@/lib/img-utils';
+import { Camera } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { ControllerRenderProps } from 'react-hook-form';
+
+type FileUploadType = {
+  field: ControllerRenderProps<
+    {
+      nickname: string;
+      email: string;
+      password: string;
+      profileImage: string;
+    },
+    'profileImage'
+  >;
+};
+
+export function FileUpload({ field }: FileUploadType) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showImageSelect, setShowImageSelect] = useState<boolean>(false);
+  const [profileImage, setProfileImage] = useState<string>(
+    'https://placehold.co/330x220?text=Profile+Image',
+  );
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    if (event.target.files) {
+      const file: File = event.target.files[0];
+      const isValid = checkImage(file, 'image');
+      if (isValid) {
+        const dataImage: string | ArrayBuffer | null = await readAsBase64(file);
+        if (typeof dataImage === 'string') {
+          setProfileImage(dataImage);
+          field.onChange(dataImage); // Update react-hook-form with the base64 image data
+        }
+      }
+      setShowImageSelect(false);
+    }
+  };
+
+  return (
+    <div
+      onMouseEnter={() => setShowImageSelect(true)}
+      onMouseLeave={() => setShowImageSelect(false)}
+      className="relative mb-5 mt-2 w-[20%] cursor-pointer"
+    >
+      {profileImage && (
+        <img
+          id="profilePicture"
+          src={profileImage}
+          alt="Profile Picture"
+          className="left-0 top-0 h-20 w-20 rounded-full bg-white object-cover"
+        />
+      )}
+      {showImageSelect && (
+        <div
+          onClick={() => fileInputRef.current?.click()}
+          className="absolute left-0 top-0 flex h-20 w-20 cursor-pointer justify-center rounded-full bg-[#dee1e7]"
+        >
+          <Camera className="flex self-center" />
+        </div>
+      )}
+      <input
+        name="image"
+        ref={fileInputRef}
+        type="file"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+        onClick={() => {
+          if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/lib/img-utils.ts
+++ b/web/src/lib/img-utils.ts
@@ -1,0 +1,111 @@
+export const validateImage = (file: File, type: string): boolean => {
+  if (type === 'image') {
+    const validImageTypes = [
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ];
+    return file && validImageTypes.indexOf(file.type) > -1;
+  } else {
+    const validVideoTypes = [
+      'video/m4v',
+      'video/avi',
+      'video/mpg',
+      'video/mp4',
+      'video/webm',
+    ];
+    return file && validVideoTypes.indexOf(file.type) > -1;
+  }
+};
+
+export const checkImageSize = (file: File, type: string): string => {
+  let fileError = '';
+  const isValid = validateImage(file, type);
+  if (!isValid) {
+    fileError = `File ${file.name} not accepted`;
+  }
+  if (file.size > 50000000) {
+    // 50 MB
+    fileError = 'File is too large.';
+  }
+  return fileError;
+};
+
+export const checkImage = (file: File, type: string): boolean => {
+  let isValid = true;
+  if (!validateImage(file, type)) {
+    window.alert(`File ${file.name} not accepted`);
+    isValid = false;
+    return false;
+  }
+  if (checkImageSize(file, type)) {
+    window.alert(checkImageSize(file, type));
+    isValid = false;
+    return false;
+  }
+  return isValid;
+};
+
+export const checkFile = (file: File): boolean => {
+  let hasError = false;
+  if (file.size > 1000000000) {
+    // 1 GB
+    window.alert('File is too large. Max. size is 1 GB.');
+    hasError = true;
+  }
+  if (
+    !file.name.match(/\.(jpg|jpeg|png|gif|pdf|webp|zip|m4v|avi|mpg|mp4|webm)$/)
+  ) {
+    window.alert('Only files of type jpg, jpeg, png, gif or pdf are allowed');
+    hasError = true;
+  }
+  return hasError;
+};
+
+export const checkUrlExtension = (fileExtension: string): string => {
+  let fileType = '';
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(fileExtension)) {
+    fileType = 'image';
+  }
+
+  if (['pdf'].includes(fileExtension)) {
+    fileType = 'pdf';
+  }
+
+  if (['m4v', 'avi', 'mpg', 'mp4', 'webm'].includes(fileExtension)) {
+    fileType = 'video';
+  }
+
+  if (['zip'].includes(fileExtension)) {
+    fileType = 'zip';
+  }
+  return fileType;
+};
+
+export const fileType = (file: File): string => {
+  const list: string[] = file.name.split('.');
+  const fileType: string = list[list.length - 1];
+  return fileType;
+};
+
+export const readAsBase64 = (
+  file: File,
+): Promise<string | ArrayBuffer | null> => {
+  const reader: FileReader = new FileReader();
+  const fileValue: Promise<string | ArrayBuffer | null> = new Promise(
+    (resolve, reject) => {
+      reader.addEventListener('load', () => {
+        resolve(reader.result);
+      });
+
+      reader.addEventListener('error', (event: ProgressEvent<FileReader>) => {
+        reject(event);
+      });
+
+      reader.readAsDataURL(file);
+    },
+  );
+  return fileValue;
+};

--- a/web/src/lib/schemas/signin.schema.ts
+++ b/web/src/lib/schemas/signin.schema.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod';
+
+export const signinSchema = z.object({
+  email: z.string().email({ message: '유효하지 않은 이메일 형식입니다.' }),
+  password: z
+    .string()
+    .min(4, { message: '비밀번호는 최소 4자리 이상이어야 합니다.' })
+    .max(12, { message: '비밀번호는 12자리 이하여야 합니다.' }),
+});

--- a/web/src/lib/schemas/signup.schema.ts
+++ b/web/src/lib/schemas/signup.schema.ts
@@ -1,0 +1,14 @@
+import * as z from 'zod';
+
+export const signupSchema = z.object({
+  nickname: z
+    .string()
+    .min(4, { message: '닉네임은 최소 4자리 이상이어야 합니다.' })
+    .max(12, { message: '닉네임은 12자리 이하여햐 합니다.' }),
+  email: z.string().email({ message: '유효하지 않은 이메일 형식입니다.' }),
+  password: z
+    .string()
+    .min(4, { message: '비밀번호는 최소 4자리 이상이어야 합니다.' })
+    .max(12, { message: '비밀번호는 12자리 이하여야 합니다.' }),
+  profileImage: z.string().min(1, { message: '프로필 이미지가 필요합니다.' }),
+});


### PR DESCRIPTION
#7 

- tailwind([shadcn-ui](https://ui.shadcn.com/))를 이용한 회원가입 / 로그인 디자인 구현
![mynote-sign](https://github.com/f-lab-edu/my-note/assets/100750188/7da3e307-3f92-40ee-9a52-30b009a82162)

- 개선 예정
   - 비밀번호 input type - password로 변경
   - 서버의 필드와 네임 통일